### PR TITLE
Youtube service relative URL fix

### DIFF
--- a/playlist_downloader/youtube/youtubeservice.py
+++ b/playlist_downloader/youtube/youtubeservice.py
@@ -20,7 +20,7 @@ class YouTubeService:
         return youtube_video
 
     def download_youtube_video_for_track(self, track: Track) -> None:
-        self.youtube_dl_options['outtmpl'] = '/downloads/' + track.get_name_and_artists_as_string() + '.%(ext)s'
+        self.youtube_dl_options['outtmpl'] = './downloads/' + track.get_name_and_artists_as_string() + '.%(ext)s'
         try:
             with yt_dlp.YoutubeDL(self.youtube_dl_options) as ydl:
                 ydl.download([track.youtube_video.url])


### PR DESCRIPTION
### Context
When executing the script on  a Unix system, youtube-dl output is written to the "/download" folder. On unix systems the "/" directory is read only and therefore the application throws the following error. 

![image](https://user-images.githubusercontent.com/6953846/149789884-aab639ce-4600-4420-94fc-4c7176a1c1c2.png)

### What has been done
- Changed "/downloads" to "./downloads" to move the download output to the working directory